### PR TITLE
Replace JSON output file with sqlite3 database

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,102 @@
+name: "python tests and coverage"
+# Uses:
+# https://github.com/actions/setup-python
+# https://github.com/actions/checkout
+# https://github.com/actions/download-artifact
+# https://github.com/actions/upload-artifact
+
+on:
+  pull_request:
+    branches:
+      - "main"
+  push:
+    branches:
+      - "main"
+
+jobs:
+  run-tests-and-coverage:
+    name: "Run nox for tests and coverage"
+    runs-on: "${{ matrix.os }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - "ubuntu-latest"
+        python-version:
+          - "3.11"
+          - "3.12"
+
+    steps:
+      - name: "Repo checkout"
+        uses: "actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11"
+
+      - name: "Set up Python ${{ matrix.python-version }}"
+        uses: "actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c"
+        with:
+          python-version: "${{ matrix.python-version }}"
+          allow-prereleases: true
+
+      - name: "Install nox"
+        run: |
+          python -m pip install --upgrade pip nox
+
+      - name: "Run tests and coverage via nox"
+        run: |
+          nox --session tests_with_coverage-${{ matrix.python-version }}
+
+      - name: "Save coverage artifact"
+        uses: "actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3"
+        with:
+          name: "coverage-artifact-${{ matrix.os}}-${{ matrix.python-version}}"
+          path: ".coverage.*"
+          retention-days: 1
+
+  coverage-compile:
+    name: "coverage compile"
+    needs: "run-tests-and-coverage"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Repo checkout"
+        uses: "actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11"
+
+      - name: "Set up Python"
+        uses: "actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c"
+        with:
+          python-version: "3.11"
+
+      - name: "Install nox"
+        run: |
+          python -m pip install --upgrade pip nox
+
+      - name: "Download coverage artifacts"
+        uses: "actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427"
+        with:
+          pattern: "coverage-artifact-*"
+          merge-multiple: true
+
+      - name: "Compile coverage data, print report"
+        run: |
+          nox --session coverage_combine_and_report
+          export TOTAL=$(python -c "import json;print(json.load(open('coverage.json'))['totals']['percent_covered_display'])")
+          echo "TOTAL=$TOTAL" >> $GITHUB_ENV
+          echo "### Total coverage: ${TOTAL}%" >> $GITHUB_STEP_SUMMARY
+
+  mypy-check:
+    name: "mypy strict enforcement"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Repo checkout"
+        uses: "actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11"
+
+      - name: "Set up Python"
+        uses: "actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c"
+        with:
+          python-version: "3.11"
+
+      - name: "Install nox"
+        run: |
+          python -m pip install --upgrade pip nox
+
+      - name: "Enforce strict type annotations with mypy"
+        run: |
+          nox --session mypy_check

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ credentials.json
 token.json
 
 # Project Files
-message_list.json
+messages.sqlite3*
 
 temp_*
 .env

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/Preocts/fetch-gmail/main.svg)](https://results.pre-commit.ci/latest/github/Preocts/fetch-gmail/main)
+[![Python tests](https://github.com/Preocts/fetch-gmail/actions/workflows/python-tests.yml/badge.svg?branch=main)](https://github.com/Preocts/fetch-gmail/actions/workflows/python-tests.yml)
+
 # fetch-gmail
 
 Fetch all available messages from a Gmail account. Output file is JSON objects

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ disallow_incomplete_defs = true
 disallow_untyped_defs = true
 no_implicit_optional = true
 warn_redundant_casts = true
-warn_unused_ignores = true
+warn_unused_ignores = false
 
 [[tool.mypy.overrides]]
 module = "tests.*"

--- a/src/fetch_gmail/fetch_gmail.py
+++ b/src/fetch_gmail/fetch_gmail.py
@@ -10,11 +10,8 @@ from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
 
-# If modifying these scopes, delete the file token.json.
 SCOPES = ["https://www.googleapis.com/auth/gmail.readonly"]
-
 MESSAGE_LIST_FILE = "message_list.json"
-POLITENESS_SLEEP = 0.25
 
 
 def authenticate() -> Credentials:
@@ -51,7 +48,7 @@ def authenticate() -> Credentials:
     return creds
 
 
-def build_message_list(creds: Credentials) -> None:
+def build_message_list(creds: Credentials, *, delay: float = 0.25) -> None:
     """
     Builds a `message_list.json` file which contains data for all messages.
 
@@ -104,10 +101,15 @@ def build_message_list(creds: Credentials) -> None:
             print("All ids captured")
             break
 
-        time.sleep(POLITENESS_SLEEP)
+        time.sleep(delay)
 
 
-def hydrate_message_list(creds: Credentials, *, save_batch_size: int = 50) -> None:
+def hydrate_message_list(
+    creds: Credentials,
+    *,
+    save_batch_size: int = 50,
+    delay: float = 0.25,
+) -> None:
     """
     Get details of any message id that has not already been fetched.
 
@@ -163,7 +165,7 @@ def hydrate_message_list(creds: Credentials, *, save_batch_size: int = 50) -> No
                 json.dump(message_json, outfile)
             save_count = 0
 
-        time.sleep(POLITENESS_SLEEP)
+        time.sleep(delay)
 
     print("Writing messages to file...")
     with open(MESSAGE_LIST_FILE, "w", encoding="utf-8") as outfile:

--- a/src/fetch_gmail/fetch_gmail.py
+++ b/src/fetch_gmail/fetch_gmail.py
@@ -5,8 +5,8 @@ import time
 
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
-from google_auth_oauthlib.flow import InstalledAppFlow
-from googleapiclient.discovery import build
+from google_auth_oauthlib.flow import InstalledAppFlow  # type: ignore
+from googleapiclient.discovery import build  # type: ignore
 
 from .messagestore import MessageStore
 

--- a/src/fetch_gmail/messagestore.py
+++ b/src/fetch_gmail/messagestore.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import sqlite3
 from collections.abc import Generator
+from collections.abc import Iterable
 
 
 class MessageStore:
@@ -18,19 +19,37 @@ class MessageStore:
             PRAGMA journal_mode=WAL;
             CREATE TABLE IF NOT EXISTS messages (
                 message_id TEXT UNIQUE,
-                [from] TEXT,
-                delivered_to TEXT,
-                subject TEXT,
-                timestamp TEXT
+                [from] TEXT DEFAULT '',
+                delivered_to TEXT DEFAULT '',
+                subject TEXT DEFAULT '',
+                timestamp TEXT DEFAULT '0'
             );
         """
 
         with self._get_cursor() as cursor:
             cursor.executescript(sql)
 
+    def save_message_ids(self, ids: Iterable[str]) -> None:
+        """
+        Save message ids to the database table.
+
+        This is an insert or ignore operation. Existing ids will be ignored.
+
+        Args:
+            ids: Iterable of message ids
+        """
+        sql = "INSERT INTO messages (message_id) VALUES (?)"
+
+        with self._get_cursor() as cursor:
+            cursor.executemany(sql, ((id_,) for id_ in ids))
+
     @contextlib.contextmanager
     def _get_cursor(self) -> Generator[sqlite3.Cursor, None, None]:
-        """Context manager for returning a cursor after opening a connection."""
+        """
+        Context manager for returning a cursor after opening a connection.
+
+        NOTE: auto commits on exit.
+        """
         try:
             connection = sqlite3.Connection(self.filename)
             connection.row_factory = sqlite3.Row
@@ -41,6 +60,7 @@ class MessageStore:
         try:
             with contextlib.closing(connection.cursor()) as cursor:
                 yield cursor
+                connection.commit()
 
         finally:
             connection.commit()

--- a/src/fetch_gmail/messagestore.py
+++ b/src/fetch_gmail/messagestore.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+from collections.abc import Generator
+
+
+class MessageStore:
+    """Data store for messages powered by sqlite3."""
+
+    def __init__(self, filename: str = "messages.sqlite3") -> None:
+        """Create a message store. Use filename ":memory:" for a memory-only store."""
+        self.filename = filename
+
+    def init_file(self) -> None:
+        """Initialize the file if required table does not exist."""
+        sql = """\
+            PRAGMA journal_mode=WAL;
+            CREATE TABLE IF NOT EXISTS messages (
+                message_id TEXT UNIQUE,
+                [from] TEXT,
+                delivered_to TEXT,
+                subject TEXT,
+                timestamp TEXT
+            );
+        """
+
+        with self._get_cursor() as cursor:
+            cursor.executescript(sql)
+
+    @contextlib.contextmanager
+    def _get_cursor(self) -> Generator[sqlite3.Cursor, None, None]:
+        """Context manager for returning a cursor after opening a connection."""
+        try:
+            connection = sqlite3.Connection(self.filename)
+            connection.row_factory = sqlite3.Row
+
+        except sqlite3.OperationalError as err:
+            raise ConnectionError() from err
+
+        try:
+            with contextlib.closing(connection.cursor()) as cursor:
+                yield cursor
+
+        finally:
+            connection.commit()
+            connection.close()

--- a/src/fetch_gmail/messagestore.py
+++ b/src/fetch_gmail/messagestore.py
@@ -43,6 +43,37 @@ class MessageStore:
         with self._get_cursor() as cursor:
             cursor.executemany(sql, ((id_,) for id_ in ids))
 
+    def update(
+        self,
+        message_id: str,
+        from_: str,
+        delivered_to: str,
+        subject: str,
+        timestamp: str,
+    ) -> None:
+        """
+        Update table row details by message_id.
+
+        Args:
+            message_id: Must exist in the table already
+            from_: Address message was delivered from (Header: From)
+            delivered_to: Address message was delivered to (Header: Delivered-To)
+            subject: Subject of the message (Header: Subject)
+            timestamp: Local timestamp of message (internalDate)
+        """
+        sql = """\
+            UPDATE messages
+            SET
+                [from]=?,
+                delivered_to=?,
+                subject=?,
+                timestamp=?
+            WHERE message_id=?;
+        """
+
+        with self._get_cursor() as cursor:
+            cursor.execute(sql, (from_, delivered_to, subject, timestamp, message_id))
+
     @contextlib.contextmanager
     def _get_cursor(self) -> Generator[sqlite3.Cursor, None, None]:
         """

--- a/src/fetch_gmail/messagestore.py
+++ b/src/fetch_gmail/messagestore.py
@@ -87,10 +87,20 @@ class MessageStore:
 
         return bool(results)
 
-    def row_count(self) -> int:
-        """Returns the total number of rows in the table."""
+    def row_count(self, *, only_empty: bool = False) -> int:
+        """
+        Returns the total number of rows in the table.
+
+        Args:
+            only_empty: When True only rows needing hydration will be counted
+        """
+        if only_empty:
+            sql = "SELECT COUNT(*) FROM messages WHERE timestamp=0"
+        else:
+            sql = "SELECT COUNT(*) FROM messages"
+
         with self._get_cursor() as cursor:
-            result = cursor.execute("SELECT COUNT(*) FROM messages").fetchone()
+            result = cursor.execute(sql).fetchone()
 
         return result["COUNT(*)"]
 

--- a/src/fetch_gmail/messagestore.py
+++ b/src/fetch_gmail/messagestore.py
@@ -80,12 +80,12 @@ class MessageStore:
         # sqlite3 does not support spreading values from one placeholder so
         # this will create as many as provided.
         ph = "?" + ",?" * (len(ids_) - 1)
-        sql = f"SELECT message_id FROM messages WHERE message_id NOT IN ({ph})"
+        sql = f"SELECT COUNT(message_id) FROM messages WHERE message_id IN ({ph})"
 
         with self._get_cursor() as cursor:
             results = cursor.execute(sql, ids_).fetchone()
 
-        return bool(results)
+        return len(ids_) != results["COUNT(message_id)"]
 
     def row_count(self, *, only_empty: bool = False) -> int:
         """

--- a/src/fetch_gmail/messagestore.py
+++ b/src/fetch_gmail/messagestore.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import contextlib
+import csv
+import os
 import sqlite3
 from collections.abc import Generator
 from collections.abc import Iterable
@@ -115,6 +117,40 @@ class MessageStore:
                 if not row:
                     break
                 yield row["message_id"]
+
+    def csv_export(self, filename: str) -> None:
+        """
+        Export MessageStore as a csv with headers.
+
+        Args:
+            filename: Full filename and path to save export to
+
+        Raises:
+            FileExistsError: When filename already exists
+        """
+        if os.path.exists(filename):
+            raise FileExistsError(f"'{filename}' already exists!")
+
+        sql = "SELECT * FROM messages"
+        csvwriter = None
+        with self._get_cursor() as cursor:
+            results = cursor.execute(sql)
+            with open(filename, "w", encoding="utf-8") as outfile:
+
+                while "Mary had a little lamb":
+                    row = results.fetchone()
+                    if not row:
+                        break
+                    if not csvwriter:
+                        fieldnames = list(row.keys())
+                        csvwriter = csv.DictWriter(
+                            outfile,
+                            fieldnames=fieldnames,
+                            lineterminator="\n",
+                        )
+                        csvwriter.writeheader()
+
+                    csvwriter.writerow({k: row[k] for k in row.keys()})
 
     @contextlib.contextmanager
     def _get_cursor(self) -> Generator[sqlite3.Cursor, None, None]:

--- a/src/fetch_gmail/messagestore.py
+++ b/src/fetch_gmail/messagestore.py
@@ -87,6 +87,13 @@ class MessageStore:
 
         return bool(results)
 
+    def row_count(self) -> int:
+        """Returns the total number of rows in the table."""
+        with self._get_cursor() as cursor:
+            result = cursor.execute("SELECT COUNT(*) FROM messages").fetchone()
+
+        return result["COUNT(*)"]
+
     @contextlib.contextmanager
     def _get_cursor(self) -> Generator[sqlite3.Cursor, None, None]:
         """

--- a/src/fetch_gmail/messagestore.py
+++ b/src/fetch_gmail/messagestore.py
@@ -94,6 +94,18 @@ class MessageStore:
 
         return result["COUNT(*)"]
 
+    def get_emtpy_message_ids(self) -> Generator[str, None, None]:
+        """Generate list of message ids that need to be hydrated."""
+        sql = "SELECT message_id FROM messages WHERE timestamp=0;"
+
+        with self._get_cursor() as cursor:
+            results = cursor.execute(sql)
+            while "The road goes ever on and on":
+                row = results.fetchone()
+                if not row:
+                    break
+                yield row["message_id"]
+
     @contextlib.contextmanager
     def _get_cursor(self) -> Generator[sqlite3.Cursor, None, None]:
         """

--- a/tests/messagestore_test.py
+++ b/tests/messagestore_test.py
@@ -84,3 +84,12 @@ def test_has_unique_ids_is_true(store: MessageStore) -> None:
     result = store.has_unique_ids({"134"})
 
     assert result is True
+
+
+def test_row_count(store: MessageStore) -> None:
+    ids = ["123", "456", "789"]
+    store.save_message_ids(ids)
+
+    result = store.row_count()
+
+    assert result == len(ids)

--- a/tests/messagestore_test.py
+++ b/tests/messagestore_test.py
@@ -95,6 +95,16 @@ def test_row_count(store: MessageStore) -> None:
     assert result == len(ids)
 
 
+def test_row_count_only_empty(store: MessageStore) -> None:
+    ids = ["123", "456", "789"]
+    store.save_message_ids(ids)
+    store.update("123", "m", "m", "m", "1")
+
+    result = store.row_count(only_empty=True)
+
+    assert result == len(ids) - 1
+
+
 def test_get_empty_mesages_ids(store: MessageStore) -> None:
     ids = ["123", "456", "789"]
     store.save_message_ids(ids)

--- a/tests/messagestore_test.py
+++ b/tests/messagestore_test.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+from collections.abc import Generator
+
+import pytest
+
+from fetch_gmail.messagestore import MessageStore
+
+
+@pytest.fixture
+def store(tmpdir) -> Generator[MessageStore, None, None]:
+    tempfile = tmpdir.join("messagestore_test_database")
+    store = MessageStore(tempfile)
+
+    try:
+        store.init_file()
+        yield store
+
+    finally:
+        os.remove(tempfile)
+
+
+def test_init_file(store: MessageStore) -> None:
+    expected = ["message_id", "from", "delivered_to", "subject", "timestamp"]
+    sql = "SELECT * from messages;"
+    conn = sqlite3.connect(store.filename)
+    store.init_file()
+
+    desc = conn.execute(sql).description
+    columns = [d[0] for d in desc]
+
+    assert columns == expected

--- a/tests/messagestore_test.py
+++ b/tests/messagestore_test.py
@@ -93,3 +93,13 @@ def test_row_count(store: MessageStore) -> None:
     result = store.row_count()
 
     assert result == len(ids)
+
+
+def test_get_empty_mesages_ids(store: MessageStore) -> None:
+    ids = ["123", "456", "789"]
+    store.save_message_ids(ids)
+
+    for idx, id_ in enumerate(store.get_emtpy_message_ids(), start=1):
+        assert id_ in ids
+
+    assert idx == len(ids)

--- a/tests/messagestore_test.py
+++ b/tests/messagestore_test.py
@@ -32,3 +32,15 @@ def test_init_file(store: MessageStore) -> None:
     columns = [d[0] for d in desc]
 
     assert columns == expected
+
+
+def test_save_messages_ignores_constraint_violations(store: MessageStore) -> None:
+    ids = ["123", "456", "789"]
+    sql = "SELECT * from messages;"
+    conn = sqlite3.connect(store.filename)
+
+    store.save_message_ids(ids)
+    results = conn.execute(sql).fetchall()
+    results = conn.execute(sql).fetchall()
+
+    assert ids == [r[0] for r in results]

--- a/tests/messagestore_test.py
+++ b/tests/messagestore_test.py
@@ -66,3 +66,21 @@ def test_update_does_not_insert_if_id_not_exists(store: MessageStore) -> None:
     results = conn.execute(sql).fetchone()
 
     assert not results
+
+
+def test_has_unique_ids_is_false(store: MessageStore) -> None:
+    ids = ["123", "456", "789"]
+    store.save_message_ids(ids)
+
+    result = store.has_unique_ids(ids)
+
+    assert result is False
+
+
+def test_has_unique_ids_is_true(store: MessageStore) -> None:
+    ids = ["123", "456", "789"]
+    store.save_message_ids(ids)
+
+    result = store.has_unique_ids({"134"})
+
+    assert result is True

--- a/tests/messagestore_test.py
+++ b/tests/messagestore_test.py
@@ -113,3 +113,26 @@ def test_get_empty_mesages_ids(store: MessageStore) -> None:
         assert id_ in ids
 
     assert idx == len(ids)
+
+
+def test_csv_export(store: MessageStore, tmpdir) -> None:
+    ids = ["123", "456", "789"]
+    store.save_message_ids(ids)
+    tempfile = tmpdir.join("messagestore_test_export")
+    expected = """\
+message_id,from,delivered_to,subject,timestamp
+123,,,,0
+456,,,,0
+789,,,,0
+"""
+
+    try:
+        store.csv_export(tempfile)
+
+        with open(tempfile, "r", encoding="utf-8") as infile:
+            contents = infile.read()
+
+        assert contents == expected
+
+    finally:
+        os.remove(tempfile)

--- a/tests/messagestore_test.py
+++ b/tests/messagestore_test.py
@@ -44,3 +44,25 @@ def test_save_messages_ignores_constraint_violations(store: MessageStore) -> Non
     results = conn.execute(sql).fetchall()
 
     assert ids == [r[0] for r in results]
+
+
+def test_update(store: MessageStore) -> None:
+    ids = ["123", "456", "789"]
+    sql = "SELECT * from messages WHERE message_id=456;"
+    conn = sqlite3.connect(store.filename)
+    store.save_message_ids(ids)
+
+    store.update("456", "mockfrom", "mockto", "mocksub", "8675309")
+    results = conn.execute(sql).fetchone()
+
+    assert results == ("456", "mockfrom", "mockto", "mocksub", "8675309")
+
+
+def test_update_does_not_insert_if_id_not_exists(store: MessageStore) -> None:
+    sql = "SELECT * from messages WHERE message_id=456;"
+    conn = sqlite3.connect(store.filename)
+
+    store.update("456", "mockfrom", "mockto", "mocksub", "8675309")
+    results = conn.execute(sql).fetchone()
+
+    assert not results


### PR DESCRIPTION
Decrease the memory overhead. Database removes the need to store all seen ids in memory as well as storing the entire JSON file contents in memory. Additional use of generators when reading from the database reduce memory overhead as well.

Include csv export function that will be implemented in the cli design next.