### PR TITLE
Store label ids in table with message data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fetch-gmail"
-version = "1.0.0"
+version = "1.1.0"
 requires-python = ">=3.11"
 description = "Download gmail email details. Captures timestamp, from, delivered-to, and subject."
 readme = "README.md"

--- a/src/fetch_gmail/fetch_gmail.py
+++ b/src/fetch_gmail/fetch_gmail.py
@@ -147,6 +147,7 @@ def hydrate_message_list(
             delivered_to=message_data.get("Delivered-To", ""),
             subject=message_data.get("Subject", ""),
             timestamp=message_data.get("Timestamp", "0"),
+            label_ids=results["labelIds"],
         )
 
         time.sleep(delay)

--- a/src/fetch_gmail/messagestore.py
+++ b/src/fetch_gmail/messagestore.py
@@ -24,7 +24,8 @@ class MessageStore:
                 [from] TEXT DEFAULT '',
                 delivered_to TEXT DEFAULT '',
                 subject TEXT DEFAULT '',
-                timestamp TEXT DEFAULT '0'
+                timestamp TEXT DEFAULT '0',
+                label_ids TEXT DEFAULT ''
             );
         """
 

--- a/src/fetch_gmail/messagestore.py
+++ b/src/fetch_gmail/messagestore.py
@@ -53,6 +53,7 @@ class MessageStore:
         delivered_to: str,
         subject: str,
         timestamp: str,
+        label_ids: Iterable[str],
     ) -> None:
         """
         Update table row details by message_id.
@@ -63,6 +64,7 @@ class MessageStore:
             delivered_to: Address message was delivered to (Header: Delivered-To)
             subject: Subject of the message (Header: Subject)
             timestamp: Local timestamp of message (internalDate)
+            label_ids: An iterable of labels on the message
         """
         sql = """\
             UPDATE messages
@@ -70,12 +72,17 @@ class MessageStore:
                 [from]=?,
                 delivered_to=?,
                 subject=?,
-                timestamp=?
+                timestamp=?,
+                label_ids=?
             WHERE message_id=?;
         """
+        labels = self._lables_to_csv(label_ids)
 
         with self._get_cursor() as cursor:
-            cursor.execute(sql, (from_, delivered_to, subject, timestamp, message_id))
+            cursor.execute(
+                sql,
+                (from_, delivered_to, subject, timestamp, labels, message_id),
+            )
 
     @staticmethod
     def _lables_to_csv(label_ids: Iterable[str]) -> str:

--- a/tests/messagestore_test.py
+++ b/tests/messagestore_test.py
@@ -23,7 +23,14 @@ def store(tmpdir) -> Generator[MessageStore, None, None]:
 
 
 def test_init_file(store: MessageStore) -> None:
-    expected = ["message_id", "from", "delivered_to", "subject", "timestamp"]
+    expected = [
+        "message_id",
+        "from",
+        "delivered_to",
+        "subject",
+        "timestamp",
+        "label_ids",
+    ]
     sql = "SELECT * from messages;"
     conn = sqlite3.connect(store.filename)
     store.init_file()
@@ -55,7 +62,7 @@ def test_update(store: MessageStore) -> None:
     store.update("456", "mockfrom", "mockto", "mocksub", "8675309")
     results = conn.execute(sql).fetchone()
 
-    assert results == ("456", "mockfrom", "mockto", "mocksub", "8675309")
+    assert results == ("456", "mockfrom", "mockto", "mocksub", "8675309", "")
 
 
 def test_update_does_not_insert_if_id_not_exists(store: MessageStore) -> None:
@@ -120,10 +127,10 @@ def test_csv_export(store: MessageStore, tmpdir) -> None:
     store.save_message_ids(ids)
     tempfile = tmpdir.join("messagestore_test_export")
     expected = """\
-message_id,from,delivered_to,subject,timestamp
-123,,,,0
-456,,,,0
-789,,,,0
+message_id,from,delivered_to,subject,timestamp,label_ids
+123,,,,0,
+456,,,,0,
+789,,,,0,
 """
 
     try:

--- a/tests/messagestore_test.py
+++ b/tests/messagestore_test.py
@@ -59,17 +59,17 @@ def test_update(store: MessageStore) -> None:
     conn = sqlite3.connect(store.filename)
     store.save_message_ids(ids)
 
-    store.update("456", "mockfrom", "mockto", "mocksub", "8675309")
+    store.update("456", "mockfrom", "mockto", "mocksub", "8675309", ["hi", "there"])
     results = conn.execute(sql).fetchone()
 
-    assert results == ("456", "mockfrom", "mockto", "mocksub", "8675309", "")
+    assert results == ("456", "mockfrom", "mockto", "mocksub", "8675309", "hi,there")
 
 
 def test_update_does_not_insert_if_id_not_exists(store: MessageStore) -> None:
     sql = "SELECT * from messages WHERE message_id=456;"
     conn = sqlite3.connect(store.filename)
 
-    store.update("456", "mockfrom", "mockto", "mocksub", "8675309")
+    store.update("456", "mockfrom", "mockto", "mocksub", "8675309", [])
     results = conn.execute(sql).fetchone()
 
     assert not results
@@ -105,7 +105,7 @@ def test_row_count(store: MessageStore) -> None:
 def test_row_count_only_empty(store: MessageStore) -> None:
     ids = ["123", "456", "789"]
     store.save_message_ids(ids)
-    store.update("123", "m", "m", "m", "1")
+    store.update("123", "m", "m", "m", "1", [])
 
     result = store.row_count(only_empty=True)
 

--- a/tests/messagestore_test.py
+++ b/tests/messagestore_test.py
@@ -143,3 +143,47 @@ message_id,from,delivered_to,subject,timestamp,label_ids
 
     finally:
         os.remove(tempfile)
+
+
+@pytest.mark.parametrize(
+    "label_ids,expected",
+    (
+        (["aaa", "bbb", "ccc"], "aaa,bbb,ccc"),
+        (['"aaa', "bbb", "ccc"], '"""aaa",bbb,ccc'),
+        (['aaa"', "bbb", "ccc"], '"aaa""",bbb,ccc'),
+        (["aaa", "b,bb", "ccc"], 'aaa,"b,bb",ccc'),
+        (["a'a'a", "b,bb", 'c"c"c'], 'a\'a\'a,"b,bb","c""c""c"'),
+        (["", "", ""], ",,"),
+    ),
+)
+def test_lables_to_csv(
+    store: MessageStore,
+    label_ids: list[str],
+    expected: str,
+) -> None:
+
+    result = store._lables_to_csv(label_ids)
+
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "csv_string,expected",
+    (
+        ("aaa,bbb,ccc", ["aaa", "bbb", "ccc"]),
+        ('"""aaa",bbb,ccc', ['"aaa', "bbb", "ccc"]),
+        ('"aaa""",bbb,ccc', ['aaa"', "bbb", "ccc"]),
+        ('aaa,"b,bb",ccc', ["aaa", "b,bb", "ccc"]),
+        ('a\'a\'a,"b,bb",c""c""c', ["a'a'a", "b,bb", 'c"c"c']),
+        (",,", ["", "", ""]),
+    ),
+)
+def test_csv_to_lables(
+    store: MessageStore,
+    csv_string: str,
+    expected: tuple[str],
+) -> None:
+
+    result = store._csv_to_labels(csv_string)
+
+    assert result == expected


### PR DESCRIPTION
Label ids are valuable for sorting and filtering the data. There are no character limitations seen in what a label can contain. Given that, storing them in a comma separated list in the table requires some sanitation of their values using RFC 4180 as a guide.

Using a separate table's rowId value as a foreign key was considered and could be a valid iteration of this implementation in the future.